### PR TITLE
Remove year 2022 from footer

### DIFF
--- a/website/src/components/footer.tsx
+++ b/website/src/components/footer.tsx
@@ -22,7 +22,7 @@ const Footer = () => {
             <div>Switzerland</div>
           </div>
           <div className={styles.footerText}>
-            ©2022 HOPR Association, all rights reserved
+            © HOPR Association, all rights reserved
           </div>
         </div>
       </div>

--- a/website/src/future-hopr-lib-components/Layout/footer.jsx
+++ b/website/src/future-hopr-lib-components/Layout/footer.jsx
@@ -142,7 +142,7 @@ const Footer = () => {
               <address>HOPR<br/>Bleicherweg 33<br/>8002 Zürich<br/>Switzerland</address>
               <address>HOPR Tech Pte. Ltd.<br/>68 Circular Road, #02-01,<br/>049422 Singapore<br/>Singapore</address>
             </Addresses>
-            <div>©2022 HOPR Association, all rights reserved</div>
+            <div>© HOPR Association, all rights reserved</div>
           </div>
         </LeftColumn>
         <div className='right-column'>


### PR DESCRIPTION
Closes: https://www.notion.so/hoprnet/remove-2022-from-footer-in-copyright-of-all-pages-9e1cc6dacd4543059a72079f9a97e819
### Tasks:
- [x] Remove year 2022 from footer
### Evidence:
![image](https://user-images.githubusercontent.com/59750365/214331839-a427650f-678e-4d3a-951d-bb7036308520.png)